### PR TITLE
refactor: simplify DefaultItem and pass down rest props

### DIFF
--- a/src/TreeList/DefaultItem.tsx
+++ b/src/TreeList/DefaultItem.tsx
@@ -13,14 +13,6 @@ import { CHILDREN } from '../utils/makeParentChildTree'
 export const EXPAND_ICON = MdAdd
 export const COLLAPSE_ICON = MdRemove
 
-const StyledItem = styled.div`
-  li:focus, :hover {
-    button {
-      outline: 5px solid ${fromTheme(theme => theme.colors.lightGray)};
-    }
-  }
-`
-
 export const ToggleExpandedButton = styled.button`
   width: 20px;
   height: 20px;
@@ -32,28 +24,40 @@ export const ToggleExpandedButton = styled.button`
   cursor: pointer;
 `
 
+const StyledListItem = styled(ListItem)`
+  &:focus,
+  &:hover {
+    ${ToggleExpandedButton} {
+      outline: 5px solid ${fromTheme(theme => theme.colors.lightGray)};
+    }
+  }
+`
+
 const StyledValue = styled.span`
-  margin-left: 10px
+  margin-left: 10px;
 `
 
 const ButtonIcon = styled(Icon)`
   svg {
     width: 100%;
     height: 100%;
-    color: ${fromTheme(theme => theme.colors.gray)}
+    color: ${fromTheme(theme => theme.colors.gray)};
   }
 `
 
 export interface TreeListItemProps<Data extends TreeListItem<SelectListData>> {
-  data: { items: Data[], onChange: (item: Data, e?: React.MouseEvent<HTMLLIElement>) => void }
+  data: { items: Data[]; onChange: (item: Data, e?: React.MouseEvent<HTMLLIElement>) => void }
   style: CSSProperties
   index: number
   isScrolling: boolean
 }
 
-export function DefaultItem<
-  Data extends TreeListItem<SelectListData>
-> ({ data, style, index }: TreeListItemProps<Data>) {
+export function DefaultItem<Data extends TreeListItem<SelectListData>> ({
+  data,
+  style,
+  index,
+  ...rest
+}: TreeListItemProps<Data>) {
   const { items, onChange } = data
   const item = items[index]
 
@@ -61,28 +65,21 @@ export function DefaultItem<
     const handleChange = (e: React.MouseEvent<HTMLLIElement>) => onChange && onChange(item, e)
 
     return (
-      <StyledItem>
-        <ListItem style={style} onClick={handleChange}>
-          <BranchSpacer
-            spacing={20}
-            index={index}
-            data={items}>
-            {item[CHILDREN] && (
-              <ToggleExpandedButton onClick={(e) => {
+      <StyledListItem style={style} onClick={handleChange} {...rest}>
+        <BranchSpacer spacing={20} index={index} data={items}>
+          {item[CHILDREN] && (
+            <ToggleExpandedButton
+              onClick={e => {
                 e.stopPropagation()
                 item.expand()
-              }}>
-                <ButtonIcon>{
-                  item.expanded
-                    ? <COLLAPSE_ICON />
-                    : <EXPAND_ICON />
-                }</ButtonIcon>
-              </ToggleExpandedButton>
-            )}
-            <StyledValue>{item.value}</StyledValue>
-          </BranchSpacer>
-        </ListItem>
-      </StyledItem>
+              }}
+            >
+              <ButtonIcon>{item.expanded ? <COLLAPSE_ICON /> : <EXPAND_ICON />}</ButtonIcon>
+            </ToggleExpandedButton>
+          )}
+          <StyledValue>{item.value}</StyledValue>
+        </BranchSpacer>
+      </StyledListItem>
     )
   }, [item, index, items, onChange])
 }

--- a/src/TreeList/TreeList.stories.tsx
+++ b/src/TreeList/TreeList.stories.tsx
@@ -4,18 +4,23 @@ import { storiesOf } from '@storybook/react'
 import { TreeList } from './TreeList'
 import { FLAT_LIST_TEST_DATA } from './stories/seed'
 import { FakeRecord } from '../useExpandable/stories/seed'
-import { CustomItem } from './stories/CustomItem'
+import { CustomItem, ModifiedDefaultItem } from './stories/Items'
 
 const parentKeyAccessor = (item: FakeRecord) => item.parentId
 
 storiesOf('organisms|TreeList', module)
-  .add('default', () => (
-    <TreeList data={FLAT_LIST_TEST_DATA} parentKeyAccessor={parentKeyAccessor}/>
-  ))
+  .add('default', () => <TreeList data={FLAT_LIST_TEST_DATA} parentKeyAccessor={parentKeyAccessor} />)
   .add('custom item', () => {
     return (
       <TreeList data={FLAT_LIST_TEST_DATA} parentKeyAccessor={parentKeyAccessor}>
         {CustomItem}
+      </TreeList>
+    )
+  })
+  .add('modified item', () => {
+    return (
+      <TreeList data={FLAT_LIST_TEST_DATA} parentKeyAccessor={parentKeyAccessor}>
+        {ModifiedDefaultItem}
       </TreeList>
     )
   })

--- a/src/TreeList/stories/Items.tsx
+++ b/src/TreeList/stories/Items.tsx
@@ -2,11 +2,12 @@ import React, { useMemo } from 'react'
 
 import { TreeListItem } from '../../useExpandable'
 import { SelectListData } from '../../SelectList/SelectList'
-import { TreeListItemProps } from '../DefaultItem'
+import { TreeListItemProps, DefaultItem, ToggleExpandedButton } from '../DefaultItem'
 import { ListItem } from '../../ListItem'
 import { BranchSpacer } from '../../BranchSpacer'
 import { CHILDREN } from '../../utils/makeParentChildTree'
 import { Button } from '../../Button'
+import styled from 'styled-components'
 
 export function CustomItem<Data extends TreeListItem<SelectListData>> ({ data, style, index }: TreeListItemProps<Data>) {
   const { items, onChange } = data
@@ -17,18 +18,19 @@ export function CustomItem<Data extends TreeListItem<SelectListData>> ({ data, s
   return useMemo(() => {
     return (
       <ListItem style={style} onClick={handleChange}>
-        <BranchSpacer
-          spacing={20}
-          index={index}
-          data={items}>
-          {item[CHILDREN] && (
-            <Button onClick={item.expand}>
-              {item.expanded ? 'Collapse' : 'Expand'}
-            </Button>
-          )}
+        <BranchSpacer spacing={20} index={index} data={items}>
+          {item[CHILDREN] && <Button onClick={item.expand}>{item.expanded ? 'Collapse' : 'Expand'}</Button>}
           {item.value}
         </BranchSpacer>
       </ListItem>
     )
   }, [item, index, items])
 }
+
+export const ModifiedDefaultItem = styled(DefaultItem)`
+  ${ToggleExpandedButton} {
+    svg {
+      color: hotpink;
+    }
+  }
+`


### PR DESCRIPTION
Removed unnecessary wrapper `div` and passed down `{...rest}` props to wrapper component so `DefaultItem` can be modified using `styled-components`.