### PR TITLE
feat: support children callback and clone element to not forward ref

### DIFF
--- a/src/Select/Select.stories.tsx
+++ b/src/Select/Select.stories.tsx
@@ -58,7 +58,7 @@ export default storiesOf('molecules/Select', module)
         data={items}
         onChange={(v) => { storeState(v) }}
         placeholder='Choose an option'
-        InputComponent={React.forwardRef((props, ref) => <SelectInput {...props} ref={ref} outlined />)}
+        inputComponent={<SelectInput outlined />}
       />
     </Row>
   ))

--- a/src/Select/Select.stories.tsx
+++ b/src/Select/Select.stories.tsx
@@ -58,7 +58,7 @@ export default storiesOf('molecules/Select', module)
         data={items}
         onChange={(v) => { storeState(v) }}
         placeholder='Choose an option'
-        inputComponent={(props: any) => <SelectInput {...props} outlined />}
+        inputComponent={(props) => <SelectInput {...props} outlined />}
       />
     </Row>
   ))

--- a/src/Select/Select.stories.tsx
+++ b/src/Select/Select.stories.tsx
@@ -58,7 +58,7 @@ export default storiesOf('molecules/Select', module)
         data={items}
         onChange={(v) => { storeState(v) }}
         placeholder='Choose an option'
-        inputComponent={<SelectInput outlined />}
+        inputComponent={(props: any) => <SelectInput {...props} outlined />}
       />
     </Row>
   ))

--- a/src/Select/Select.test.tsx
+++ b/src/Select/Select.test.tsx
@@ -54,9 +54,7 @@ describe('The Select component', () => {
         selected={{ key: 'one', value: 'one' }}
         onChange={(() => null)}
         data={[]}
-        InputComponent={React.forwardRef((props, ref) => (
-          <input id='test-id' {...props} ref={ref as any} />
-        ))}
+        inputComponent={<input id='test-id' />}
       />
     ))
 

--- a/src/Select/Select.test.tsx
+++ b/src/Select/Select.test.tsx
@@ -54,7 +54,7 @@ describe('The Select component', () => {
         selected={{ key: 'one', value: 'one' }}
         onChange={(() => null)}
         data={[]}
-        inputComponent={<input id='test-id' />}
+        inputComponent={(props) => <input id='test-id' {...props}/>}
       />
     ))
 

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -44,7 +44,7 @@ type ChildrenCallback = {
 export interface SelectProps<V> extends Pick<DropdownProps, 'placement'> {
   selected: V
   inputValueAccessor?: (item: V) => string
-  inputComponent?: React.ReactElement<SelectInputComponentProps>
+  inputComponent?: any
   data?: V extends SelectListData ? V[] : never
   onChange?: V extends SelectListData ? ((item: V) => void) : never
   name?: string
@@ -98,7 +98,7 @@ export function Select <V = string> ({
       useTriggerWidth={useInputComponentWidth}
       trigger={
         inputComponent
-          ? React.cloneElement(inputComponent, { ...inputProps })
+          ? inputComponent(inputProps)
           : <SelectInput {...inputProps} />
       }
       onOutsideClick={() => {

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -44,7 +44,7 @@ type ChildrenCallback = {
 export interface SelectProps<V> extends Pick<DropdownProps, 'placement'> {
   selected: V
   inputValueAccessor?: (item: V) => string
-  inputComponent?: any
+  inputComponent?: React.ReactElement<SelectInputComponentProps>
   data?: V extends SelectListData ? V[] : never
   onChange?: V extends SelectListData ? ((item: V) => void) : never
   name?: string

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -89,23 +89,6 @@ export function Select <V = string> ({
     onChange: () => null
   }
 
-  const renderChildren = () => {
-    if (typeof children === 'function') {
-      return children({ close })
-    }
-
-    return children || (
-      <SelectList<V extends SelectListData ? V : never>
-        value={selected as V extends SelectListData ? V : never}
-        data={data as any[] || []}
-        onChange={(v) => {
-          onChange && onChange(v)
-          close()
-        }}
-      />
-    )
-  }
-
   return (
     <Dropdown
       {...rest}
@@ -127,7 +110,21 @@ export function Select <V = string> ({
       }}
     >
       <OptionsWrapper fullWidth={useInputComponentWidth}>
-        {renderChildren()}
+        {
+          typeof children === 'function'
+            ? children({ close })
+            : (
+              children ||
+              <SelectList<V extends SelectListData ? V : never>
+                value={selected as V extends SelectListData ? V : never}
+                data={data as any[] || []}
+                onChange={(v) => {
+                  onChange && onChange(v)
+                  close()
+                }}
+              />
+            )
+        }
       </OptionsWrapper>
     </Dropdown>
   )

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -44,7 +44,7 @@ type ChildrenCallback = {
 export interface SelectProps<V> extends Pick<DropdownProps, 'placement'> {
   selected: V
   inputValueAccessor?: (item: V) => string
-  inputComponent?: any
+  inputComponent?: (props: SelectInputComponentProps) => JSX.Element
   data?: V extends SelectListData ? V[] : never
   onChange?: V extends SelectListData ? ((item: V) => void) : never
   name?: string


### PR DESCRIPTION
- Support render prop callback with close method
- Clone inputComponent so we dont have to use forwardRef
- Rename InputComponent prop to inputComponent (Component itself starts with capital, i dont think there is need for the prop to start with one, so then stick to convention) 